### PR TITLE
修复 dev server 在 linux 系统下无法启动的错误

### DIFF
--- a/packages/debug-server-next/src/child-process/adb.ts
+++ b/packages/debug-server-next/src/child-process/adb.ts
@@ -43,8 +43,8 @@ export const startAdbProxy = async () => {
     [OSType.Darwin]: '../build/mac/adb',
     [OSType.Windows]: '../build/win/adb.exe',
   }[os.type()];
-  const adbPath = path.join(__dirname, adbRelatePath);
   try {
+    const adbPath = path.join(__dirname, adbRelatePath);
     if (port) await exec(adbPath, ['reverse', `tcp:${port}`, `tcp:${port}`]);
     if (hmrPort) await exec(adbPath, ['reverse', `tcp:${hmrPort}`, `tcp:${hmrPort}`]);
   } catch (e) {


### PR DESCRIPTION
在 Linux 或其他非 Darwin/Window 的系统中，此处的 `path.join` 会报错导致 `Server.initialize` 流程被打断，dev server 无法启正常运行。

后续建议改为使用开发者自己系统安装的 adb，找不到跳过就好。有端口映射需求的一定已经配置了 adb，不需要特意在 module 中附带一份。